### PR TITLE
Refactor the template using io_lib.format

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -19,7 +19,8 @@ defmodule NervesMOTD do
   """
   @type option() :: {:logo, iodata()}
 
-  @typep cell :: {String.t(), iodata()} | {String.t(), iodata(), :green | :red}
+  @typep color() :: :red | :green
+  @typep cell() :: {String.t(), iodata()} | {String.t(), iodata(), color()}  
 
   @doc """
   Print the message of the day

--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -12,6 +12,7 @@ defmodule NervesMOTD do
   \e[34m█▌ \e[36m▐█▄▖\e[34m▝▀█▌ \e[36m▐█   \e[39mN  E  R  V  E  S
   \e[34m█▌   \e[36m▝▀█▙▄▖ ▐█
   \e[34m███▌    \e[36m▀▜████\e[0m
+
   """
 
   @typedoc """
@@ -34,16 +35,17 @@ defmodule NervesMOTD do
   def print(opts \\ []) do
     {:ok, _} = Application.ensure_all_started(:nerves_runtime)
 
-    IO.puts(logo(opts))
-
-    IO.puts(uname())
-
-    Enum.each(rows(), &IO.puts(["  ", format_row(&1)]))
-
-    IO.puts("""
-
-    Nerves CLI help: https://hexdocs.pm/nerves/using-the-cli.html
-    """)
+    [
+      logo(opts),
+      uname(),
+      "\n",
+      Enum.map(rows(), &format_row/1),
+      "\n",
+      """
+      Nerves CLI help: https://hexdocs.pm/nerves/using-the-cli.html
+      """
+    ]
+    |> IO.puts()
   end
 
   @spec logo([option()]) :: iodata()
@@ -65,16 +67,16 @@ defmodule NervesMOTD do
 
   @spec format_row([cell()]) :: iolist()
   # A blank line
-  defp format_row([]), do: []
+  defp format_row([]), do: ["\n"]
 
   # A row with full width
   defp format_row([{label, formatted_iodata}]) do
-    :io_lib.format("~-12ts : ~s", [label, formatted_iodata])
+    :io_lib.format("  ~-12ts : ~s\n", [label, formatted_iodata])
   end
 
   # A row with two columns
   defp format_row([col0, col1]) do
-    [format_cell(col0, 0), format_cell(col1, 1)]
+    ["  ", format_cell(col0, 0), format_cell(col1, 1), "\n"]
   end
 
   @spec format_cell(cell(), 0 | 1) :: iolist()

--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -20,7 +20,7 @@ defmodule NervesMOTD do
   @type option() :: {:logo, iodata()}
 
   @typep color() :: :red | :green
-  @typep cell() :: {String.t(), iodata()} | {String.t(), iodata(), color()}  
+  @typep cell() :: {String.t(), iodata()} | {String.t(), iodata(), color()}
 
   @doc """
   Print the message of the day
@@ -86,23 +86,10 @@ defmodule NervesMOTD do
     |> :io_lib.format([label, formatted_iodata])
   end
 
-  defp format_cell({label, formatted_iodata, :green}, column_index) do
+  defp format_cell({label, formatted_iodata, color}, column_index) do
     [
       :io_lib.format("~-12ts : ", [label]),
-      IO.ANSI.green(),
-      case column_index do
-        0 -> "~-24ts"
-        _ -> "~s"
-      end
-      |> :io_lib.format([formatted_iodata]),
-      IO.ANSI.reset()
-    ]
-  end
-
-  defp format_cell({label, formatted_iodata, :red}, column_index) do
-    [
-      :io_lib.format("~-12ts : ", [label]),
-      IO.ANSI.red(),
+      apply(IO.ANSI, color, []),
       case column_index do
         0 -> "~-24ts"
         _ -> "~s"

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -46,27 +46,27 @@ defmodule NervesMOTDTest do
   end
 
   test "Uptime" do
-    assert capture_motd() =~ ~r/Uptime : .*\d{0,2} seconds/
+    assert capture_motd() =~ ~r/Uptime       : .*\d{0,2} seconds/
   end
 
   test "Clock" do
-    assert capture_motd() =~ ~r/Clock  : \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/
+    assert capture_motd() =~ ~r/Clock        : \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/
   end
 
   test "Firmware when valid" do
     Mox.expect(NervesMOTD.MockRuntime, :firmware_valid?, 1, fn -> true end)
-    assert capture_motd() =~ ~r/\e\[32mValid/
+    assert capture_motd() =~ ~r/Firmware     : \e\[32mValid.*\e\[0m/
   end
 
   test "Firmware when invalid" do
     Mox.expect(NervesMOTD.MockRuntime, :firmware_valid?, 1, fn -> false end)
-    assert capture_motd() =~ ~r/\e\[31mNot validated/
+    assert capture_motd() =~ ~r/Firmware     : \e\[31mNot validated.*\e\[0m/
   end
 
   test "Applications when all apps started" do
     apps = %{started: [:a, :b, :c], loaded: [:a, :b, :c]}
     Mox.expect(NervesMOTD.MockRuntime, :applications, 1, fn -> apps end)
-    assert capture_motd() =~ ~r/Applications : \e\[32m\d* \/ \d*\e\[0m/
+    assert capture_motd() =~ ~r/Applications : \e\[32m\d* \/ \d*.*\e\[0m/
   end
 
   test "Applications when not all apps started" do
@@ -76,7 +76,7 @@ defmodule NervesMOTDTest do
   end
 
   test "Hostname" do
-    assert capture_motd() =~ ~r/Hostname     : \e\[0m[0-9a-zA-Z\-]*\e\[0m/
+    assert capture_motd() =~ ~r/Hostname     : [0-9a-zA-Z\-]*/
   end
 
   test "Networks" do
@@ -85,12 +85,12 @@ defmodule NervesMOTDTest do
 
   test "Memory usage when ok" do
     Mox.expect(NervesMOTD.MockRuntime, :memory_usage, 1, fn -> [316_664, 78_408, 0, 0, 0, 0] end)
-    assert capture_motd() =~ ~r/Memory usage : \e\[0m78 MB \(25%\)\e\[0m/
+    assert capture_motd() =~ ~r/Memory usage : 78 MB \(25%\)/
   end
 
   test "Memory usage when high" do
     Mox.expect(NervesMOTD.MockRuntime, :memory_usage, 1, fn -> [316_664, 316_664, 0, 0, 0, 0] end)
-    assert capture_motd() =~ ~r/Memory usage : \e\[31m316 MB \(100%\)\e\[0m/
+    assert capture_motd() =~ ~r/Memory usage : \e\[31m316 MB \(100%\).*\e\[0m/
   end
 
   test "Load average" do


### PR DESCRIPTION
- Utilize [`io_lib.format/2`](https://erlang.org/doc/man/io_lib.html#format-2) and lists instead of string concatenation
- At the high level, nothing much is changed

### Notes

- ~After all I did not need any padding for holding consistent space. Tabs (`\t`) do that job.~
- Format consistent spacing using a `t` specifier instead of using tabs.
- Re-structure the template using a list of tuples so that we can format the cells before applying ANSI colors that was messing up the spacing.