### PR TITLE
Simplify load average indicator

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -145,9 +145,12 @@ defmodule NervesMOTD do
     [_total, _used, _free, _shared, _buff, _available] = runtime_mod().memory_usage()
   end
 
-  @spec load_average() :: String.t()
+  @spec load_average() :: iodata()
   defp load_average() do
-    runtime_mod().load_average()
+    case runtime_mod().load_average() do
+      [a, b, c | _] -> [a, " ", b, " ", c]
+      _ -> "error"
+    end
   end
 
   @spec hostname() :: String.t()

--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -2,7 +2,7 @@ defmodule NervesMOTD.Runtime do
   @moduledoc false
   @callback applications() :: %{started: [atom()], loaded: [atom()]}
   @callback firmware_valid?() :: boolean()
-  @callback load_average() :: binary() | nil
+  @callback load_average() :: [String.t()]
   @callback memory_usage() :: [integer()]
 end
 
@@ -26,8 +26,8 @@ defmodule NervesMOTD.Runtime.Target do
   @impl NervesMOTD.Runtime
   def load_average() do
     case File.read("/proc/loadavg") do
-      {:ok, data_str} -> String.trim(data_str)
-      _ -> nil
+      {:ok, data_str} -> String.split(data_str, " ")
+      _ -> []
     end
   end
 

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -94,6 +94,11 @@ defmodule NervesMOTDTest do
   end
 
   test "Load average" do
-    assert capture_motd() =~ ~r/Load average : 0.35 0.16 0.11 2\/70 1536/
+    assert capture_motd() =~ ~r/Load average : 0.35 0.16 0.11/
+  end
+
+  test "Load average error" do
+    Mox.expect(NervesMOTD.MockRuntime, :load_average, 1, fn -> [] end)
+    assert capture_motd() =~ ~r/Load average : error/
   end
 end

--- a/test/support/runtime.ex
+++ b/test/support/runtime.ex
@@ -25,7 +25,7 @@ defmodule NervesMOTD.Runtime.Host do
   def firmware_valid?(), do: true
 
   @impl NervesMOTD.Runtime
-  def load_average(), do: "0.35 0.16 0.11 2/70 1536"
+  def load_average(), do: ["0.35", "0.16", "0.11", "2/70", "1536"]
 
   @impl NervesMOTD.Runtime
   def memory_usage(), do: [316_664, 78_408, 126_776, 12, 111_480, 238_564]


### PR DESCRIPTION
- Before `0.35 0.16 0.11 2/70 1536`
- The typical way is to chop the last two elements.
- After `0.35 0.16 0.1`