### PR TITLE
Make the logo always be iodata

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -18,7 +18,7 @@ defmodule NervesMOTD do
   @typedoc """
   MOTD options
   """
-  @type option() :: {:logo, iodata() | false}
+  @type option() :: {:logo, iodata()}
 
   @doc """
   Print the message of the day
@@ -26,7 +26,7 @@ defmodule NervesMOTD do
   Options:
 
   * `:logo` - a custom logo to display instead of the default Nerves logo. Pass
-    `false` or `""` for no logo.
+    an empty logo (`""`) to remove it completely.
   """
   @spec print([option()]) :: :ok
   def print(opts \\ []) do
@@ -53,7 +53,7 @@ defmodule NervesMOTD do
   end
 
   defp logo_text(opts) do
-    Keyword.get(opts, :logo, @logo) || []
+    Keyword.get(opts, :logo, @logo)
   end
 
   defp firmware_text() do

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -37,7 +37,7 @@ defmodule NervesMOTDTest do
   end
 
   test "No logo" do
-    refute capture_motd(logo: false) =~ @nerves_logo_regex
+    refute capture_motd(logo: "") =~ @nerves_logo_regex
   end
 
   test "Uname" do


### PR DESCRIPTION
This removes `false` which turned out to be the same as passing an empty
iodata (like `""` or `[]`).

This also updates the docs to talk about passing an empty logo and that
being the way to make it not show the default.
