### PR TITLE
Change "Invalid" to "Not validated"

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -43,9 +43,9 @@ defmodule NervesMOTD do
         Uptime : #{uptime()}
         Clock  : #{clock()}
 
-        Firmware     : #{String.pad_trailing(firmware_text(), 20, " ")}\tApplications : #{application_text()}
-        Memory usage : #{String.pad_trailing(memory_usage_text(), 20, " ")}\tLoad average : #{load_average()}
-        Hostname     : #{String.pad_trailing(hostname_text(), 20, " ")}\tNetworks     : #{networks_text()}
+        Firmware     : #{String.pad_trailing(firmware_text(), 24, " ")}\tApplications : #{application_text()}
+        Memory usage : #{String.pad_trailing(memory_usage_text(), 24, " ")}\tLoad average : #{load_average()}
+        Hostname     : #{String.pad_trailing(hostname_text(), 24, " ")}\tNetworks     : #{networks_text()}
 
       Nerves CLI help: https://hexdocs.pm/nerves/using-the-cli.html
       """
@@ -62,7 +62,7 @@ defmodule NervesMOTD do
     if firmware_valid?() do
       IO.ANSI.green() <> "Valid (#{fw_active})"
     else
-      IO.ANSI.red() <> "Invalid (#{fw_active})"
+      IO.ANSI.red() <> "Not validated (#{fw_active})"
     end <> IO.ANSI.reset()
   end
 

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -60,7 +60,7 @@ defmodule NervesMOTDTest do
 
   test "Firmware when invalid" do
     Mox.expect(NervesMOTD.MockRuntime, :firmware_valid?, 1, fn -> false end)
-    assert capture_motd() =~ ~r/\e\[31mInvalid/
+    assert capture_motd() =~ ~r/\e\[31mNot validated/
   end
 
   test "Applications when all apps started" do


### PR DESCRIPTION
This is subtle. The firmware isn't necessarily invalid yet. It just
hasn't been marked valid yet. This tries to make the distinction.

The column width had to be bumped out a few characters due to the longer
text.
