### PR TITLE
Use round instead of trunc for percentage

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -86,7 +86,7 @@ defmodule NervesMOTD do
 
   defp memory_usage_text() do
     [memory_usage_total, memory_usage_used | _] = runtime_mod().memory_usage()
-    percentage = trunc(memory_usage_used / memory_usage_total * 100)
+    percentage = round(memory_usage_used / memory_usage_total * 100)
 
     if(percentage < 85, do: IO.ANSI.reset(), else: IO.ANSI.red()) <>
       "#{div(memory_usage_used, 1000)} MB (#{percentage}%)" <>

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -85,7 +85,7 @@ defmodule NervesMOTDTest do
 
   test "Memory usage when ok" do
     Mox.expect(NervesMOTD.MockRuntime, :memory_usage, 1, fn -> [316_664, 78_408, 0, 0, 0, 0] end)
-    assert capture_motd() =~ ~r/Memory usage : \e\[0m78 MB \(24%\)\e\[0m/
+    assert capture_motd() =~ ~r/Memory usage : \e\[0m78 MB \(25%\)\e\[0m/
   end
 
   test "Memory usage when high" do


### PR DESCRIPTION
This makes the memory usage percentage value more accurate particularly when usage is low.