### PR TITLE
Add active app partition usage indicator

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -147,12 +147,11 @@ defmodule NervesMOTD do
 
   @spec active_application_partition_cell() :: cell()
   defp active_application_partition_cell() do
-    [app_part_size, app_part_used, _, percentage_text | _] =
-      runtime_mod().sd_card()[Nerves.Runtime.KV.get_active("nerves_fw_application_part0_devpath")]
+    app_partition_path = Nerves.Runtime.KV.get_active("nerves_fw_application_part0_devpath")
+    stats = runtime_mod().filesystem_stats(app_partition_path)
+    text = :io_lib.format("~p MB (~p%)", [stats.used_mb, stats.used_percent])
 
-    text = :io_lib.format("~s / ~s MB (~s)", [app_part_used, app_part_size, percentage_text])
-
-    if elem(Integer.parse(percentage_text), 0) < 85 do
+    if stats.used_percent < 85 do
       {"Part usage", text}
     else
       {"Part usage", text, :red}

--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -148,13 +148,19 @@ defmodule NervesMOTD do
   @spec active_application_partition_cell() :: cell()
   defp active_application_partition_cell() do
     app_partition_path = Nerves.Runtime.KV.get_active("nerves_fw_application_part0_devpath")
-    stats = runtime_mod().filesystem_stats(app_partition_path)
-    text = :io_lib.format("~p MB (~p%)", [stats.used_mb, stats.used_percent])
 
-    if stats.used_percent < 85 do
-      {"Part usage", text}
-    else
-      {"Part usage", text, :red}
+    case runtime_mod().filesystem_stats(app_partition_path) do
+      {:ok, stats} ->
+        text = :io_lib.format("~p MB (~p%)", [stats.used_mb, stats.used_percent])
+
+        if stats.used_percent < 85 do
+          {"Part usage", text}
+        else
+          {"Part usage", text, :red}
+        end
+
+      :error ->
+        {"Part usage", "not available", :red}
     end
   end
 

--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -60,8 +60,9 @@ defmodule NervesMOTD do
       [{"Clock", clock()}],
       [],
       [firmware_cell(), applications_cell()],
-      [memory_usage_cell(), {"Load average", load_average()}],
-      [{"Hostname", hostname()}, {"Networks", network_names()}]
+      [memory_usage_cell(), active_application_partition_cell()],
+      [{"Hostname", hostname()}, {"Load average", load_average()}],
+      [{"Networks", network_names()}]
     ]
   end
 
@@ -141,6 +142,20 @@ defmodule NervesMOTD do
       {"Memory usage", text}
     else
       {"Memory usage", text, :red}
+    end
+  end
+
+  @spec active_application_partition_cell() :: cell()
+  defp active_application_partition_cell() do
+    [app_part_size, app_part_used, _, percentage_text | _] =
+      runtime_mod().sd_card()[Nerves.Runtime.KV.get_active("nerves_fw_application_part0_devpath")]
+
+    text = :io_lib.format("~s / ~s MB (~s)", [app_part_used, app_part_size, percentage_text])
+
+    if elem(Integer.parse(percentage_text), 0) < 85 do
+      {"Part usage", text}
+    else
+      {"Part usage", text, :red}
     end
   end
 

--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -74,5 +74,8 @@ defmodule NervesMOTD.Runtime.Target do
     else
       _ -> :error
     end
+  rescue
+    # In case the `df` command is not available.
+    ErlangError -> :error
   end
 end

--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -59,23 +59,16 @@ defmodule NervesMOTD.Runtime.Target do
     #     Filesystem           1M-blocks      Used Available Use% Mounted on
     #     /dev/mmcblk0p4            1534       205      1329  13% /root
 
-    with {df_results, 0} <- System.cmd("df", ["-m", filename]),
-         [_title_row, results_row | _] <- String.split(df_results, "\n"),
-         [_fs, size_mb_str, used_str, _avail, used_percent_str | _] <- String.split(results_row),
-         {size_mb, ""} <- Integer.parse(size_mb_str),
-         {used_mb, ""} <- Integer.parse(used_str),
-         {used_percent, "%"} <- Integer.parse(used_percent_str) do
-      {:ok,
-       %{
-         size_mb: size_mb,
-         used_mb: used_mb,
-         used_percent: used_percent
-       }}
-    else
-      _ -> :error
-    end
+    {df_results, 0} = System.cmd("df", ["-m", filename])
+    [_title_row, results_row | _] = String.split(df_results, "\n")
+    [_fs, size_mb_str, used_mb_str, _avail, used_percent_str | _] = String.split(results_row)
+    {size_mb, ""} = Integer.parse(size_mb_str)
+    {used_mb, ""} = Integer.parse(used_mb_str)
+    {used_percent, "%"} = Integer.parse(used_percent_str)
+
+    {:ok, %{size_mb: size_mb, used_mb: used_mb, used_percent: used_percent}}
   rescue
-    # In case the `df` command is not available.
-    ErlangError -> :error
+    # In case the `df` command is not available or any of the out parses incorrectly
+    _error -> :error
   end
 end

--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -4,6 +4,7 @@ defmodule NervesMOTD.Runtime do
   @callback firmware_valid?() :: boolean()
   @callback load_average() :: [String.t()]
   @callback memory_usage() :: [integer()]
+  @callback sd_card() :: %{String.t() => iolist()}
 end
 
 defmodule NervesMOTD.Runtime.Target do
@@ -42,5 +43,17 @@ defmodule NervesMOTD.Runtime.Target do
       |> String.split()
       |> tl
       |> Enum.map(&String.to_integer/1)
+  end
+
+  @impl NervesMOTD.Runtime
+  def sd_card() do
+    System.cmd("df", ["-m"])
+    |> elem(0)
+    |> String.split("\n")
+    |> tl
+    |> Enum.map(&String.split/1)
+    |> Enum.reject(&match?([], &1))
+    |> Enum.map(fn [path | data] -> {path, data} end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -52,23 +52,25 @@ defmodule NervesMOTD.Runtime.Target do
 
   @impl NervesMOTD.Runtime
   def filesystem_stats(filename) when is_binary(filename) do
-    with {df_results, 0} <- System.cmd("df", ["-m", filename]) do
-      [size_mb, used_mb, _, used_percent, _] =
-        df_results
-        |> String.split("\n")
-        |> tl
-        |> Enum.map(&String.split/1)
-        |> Enum.reject(&match?([], &1))
-        |> Enum.map(fn [_path | data] -> data end)
-        |> hd
+    case System.cmd("df", ["-m", filename]) do
+      {df_results, 0} ->
+        [size_mb, used_mb, _, used_percent, _] =
+          df_results
+          |> String.split("\n")
+          |> tl
+          |> Enum.map(&String.split/1)
+          |> Enum.reject(&match?([], &1))
+          |> Enum.map(fn [_path | data] -> data end)
+          |> hd
 
-      %{
-        size_mb: elem(Integer.parse(size_mb), 0),
-        used_mb: elem(Integer.parse(used_mb), 0),
-        used_percent: elem(Integer.parse(used_percent), 0)
-      }
-    else
-      _ -> raise "File not found"
+        %{
+          size_mb: elem(Integer.parse(size_mb), 0),
+          used_mb: elem(Integer.parse(used_mb), 0),
+          used_percent: elem(Integer.parse(used_percent), 0)
+        }
+
+      _ ->
+        raise "File not found"
     end
   end
 end

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -108,7 +108,7 @@ defmodule NervesMOTDTest do
 
   test "Application partition usage high" do
     Mox.expect(NervesMOTD.MockRuntime, :filesystem_stats, 1, fn _path ->
-      %{size_mb: 14300, used_mb: 12900, used_percent: 90}
+      %{size_mb: 14_300, used_mb: 12_900, used_percent: 90}
     end)
 
     assert capture_motd() =~ ~r/Part usage   : \e\[31m12900 MB \(90%\)\e\[0m/

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -103,14 +103,14 @@ defmodule NervesMOTDTest do
   end
 
   test "Application partition usage" do
-    assert capture_motd() =~ ~r/Part usage   : 37 \/ 14619 MB \(0%\)/
+    assert capture_motd() =~ ~r/Part usage   : 37 MB \(0%\)/
   end
 
   test "Application partition usage high" do
-    Mox.expect(NervesMOTD.MockRuntime, :sd_card, 1, fn ->
-      %{"/dev/mmcblk0p3" => ["14300", "12900", "_", "90%", "_"]}
+    Mox.expect(NervesMOTD.MockRuntime, :filesystem_stats, 1, fn _path ->
+      %{size_mb: 14300, used_mb: 12900, used_percent: 90}
     end)
 
-    assert capture_motd() =~ ~r/Part usage   : \e\[31m12900 \/ 14300 MB \(90%\)\e\[0m/
+    assert capture_motd() =~ ~r/Part usage   : \e\[31m12900 MB \(90%\)\e\[0m/
   end
 end

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -108,9 +108,17 @@ defmodule NervesMOTDTest do
 
   test "Application partition usage high" do
     Mox.expect(NervesMOTD.MockRuntime, :filesystem_stats, 1, fn _path ->
-      %{size_mb: 14_300, used_mb: 12_900, used_percent: 90}
+      {:ok, %{size_mb: 14_300, used_mb: 12_900, used_percent: 90}}
     end)
 
     assert capture_motd() =~ ~r/Part usage   : \e\[31m12900 MB \(90%\)\e\[0m/
+  end
+
+  test "Application partition usage not available" do
+    Mox.expect(NervesMOTD.MockRuntime, :filesystem_stats, 1, fn _path ->
+      :error
+    end)
+
+    assert capture_motd() =~ ~r/Part usage   : \e\[31mnot available\e\[0m/
   end
 end

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -101,4 +101,16 @@ defmodule NervesMOTDTest do
     Mox.expect(NervesMOTD.MockRuntime, :load_average, 1, fn -> [] end)
     assert capture_motd() =~ ~r/Load average : error/
   end
+
+  test "Application partition usage" do
+    assert capture_motd() =~ ~r/Part usage   : 37 \/ 14619 MB \(0%\)/
+  end
+
+  test "Application partition usage high" do
+    Mox.expect(NervesMOTD.MockRuntime, :sd_card, 1, fn ->
+      %{"/dev/mmcblk0p3" => ["14300", "12900", "_", "90%", "_"]}
+    end)
+
+    assert capture_motd() =~ ~r/Part usage   : \e\[31m12900 \/ 14300 MB \(90%\)\e\[0m/
+  end
 end

--- a/test/support/runtime.ex
+++ b/test/support/runtime.ex
@@ -31,13 +31,5 @@ defmodule NervesMOTD.Runtime.Host do
   def memory_usage(), do: [316_664, 78_408, 126_776, 12, 111_480, 238_564]
 
   @impl NervesMOTD.Runtime
-  def sd_card() do
-    %{
-      "/dev/mmcblk0p1" => ["19", "6", "13", "32%", "/boot"],
-      "/dev/mmcblk0p3" => ["14619", "37", "13821", "0%", "/root"],
-      "/dev/root" => ["39", "39", "0", "100%", "/"],
-      "devtmpfs" => ["1", "0", "1", "0%", "/dev"],
-      "tmpfs" => ["1", "0", "1", "0%", "/sys/fs/cgroup"]
-    }
-  end
+  def filesystem_stats(_filename), do: %{size_mb: 14619, used_mb: 37, used_percent: 0}
 end

--- a/test/support/runtime.ex
+++ b/test/support/runtime.ex
@@ -29,4 +29,15 @@ defmodule NervesMOTD.Runtime.Host do
 
   @impl NervesMOTD.Runtime
   def memory_usage(), do: [316_664, 78_408, 126_776, 12, 111_480, 238_564]
+
+  @impl NervesMOTD.Runtime
+  def sd_card() do
+    %{
+      "/dev/mmcblk0p1" => ["19", "6", "13", "32%", "/boot"],
+      "/dev/mmcblk0p3" => ["14619", "37", "13821", "0%", "/root"],
+      "/dev/root" => ["39", "39", "0", "100%", "/"],
+      "devtmpfs" => ["1", "0", "1", "0%", "/dev"],
+      "tmpfs" => ["1", "0", "1", "0%", "/sys/fs/cgroup"]
+    }
+  end
 end

--- a/test/support/runtime.ex
+++ b/test/support/runtime.ex
@@ -31,5 +31,5 @@ defmodule NervesMOTD.Runtime.Host do
   def memory_usage(), do: [316_664, 78_408, 126_776, 12, 111_480, 238_564]
 
   @impl NervesMOTD.Runtime
-  def filesystem_stats(_filename), do: %{size_mb: 14_619, used_mb: 37, used_percent: 0}
+  def filesystem_stats(_filename), do: {:ok, %{size_mb: 14_619, used_mb: 37, used_percent: 0}}
 end

--- a/test/support/runtime.ex
+++ b/test/support/runtime.ex
@@ -31,5 +31,5 @@ defmodule NervesMOTD.Runtime.Host do
   def memory_usage(), do: [316_664, 78_408, 126_776, 12, 111_480, 238_564]
 
   @impl NervesMOTD.Runtime
-  def filesystem_stats(_filename), do: %{size_mb: 14619, used_mb: 37, used_percent: 0}
+  def filesystem_stats(_filename), do: %{size_mb: 14_619, used_mb: 37, used_percent: 0}
 end


### PR DESCRIPTION

<img width="712" alt="Screen Shot 2021-09-18 at 3 27 57 PM" src="https://user-images.githubusercontent.com/7563926/133906412-acf721a0-dadf-40fe-87bd-6e773955ae80.png">


### Notes

- Get SD card usage with `df` command
- Change ANSI color to red when usage is high
- There might be a better label - disk space?
