### PR TITLE
Improve memory stats related

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -138,14 +138,18 @@ defmodule NervesMOTD do
 
   @spec memory_usage_cell() :: cell()
   defp memory_usage_cell() do
-    [memory_usage_total, memory_usage_used | _] = runtime_mod().memory_usage()
-    percentage = round(memory_usage_used / memory_usage_total * 100)
-    text = :io_lib.format("~p MB (~p%)", [div(memory_usage_used, 1000), percentage])
+    case runtime_mod().memory_stats() do
+      {:ok, stats} ->
+        text = :io_lib.format("~p MB (~p%)", [stats.used_mb, stats.used_percent])
 
-    if percentage < 85 do
-      {"Memory usage", text}
-    else
-      {"Memory usage", text, :red}
+        if stats.used_percent < 85 do
+          {"Memory usage", text}
+        else
+          {"Memory usage", text, :red}
+        end
+
+      :error ->
+        {"Memory usage", "not available", :red}
     end
   end
 

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -80,12 +80,14 @@ defmodule NervesMOTDTest do
   end
 
   test "Memory usage when ok" do
-    Mox.expect(NervesMOTD.MockRuntime, :memory_usage, 1, fn -> [316_664, 78_408, 0, 0, 0, 0] end)
     assert capture_motd() =~ ~r/Memory usage : 78 MB \(25%\)/
   end
 
   test "Memory usage when high" do
-    Mox.expect(NervesMOTD.MockRuntime, :memory_usage, 1, fn -> [316_664, 316_664, 0, 0, 0, 0] end)
+    Mox.expect(NervesMOTD.MockRuntime, :memory_stats, 1, fn ->
+      {:ok, %{size_mb: 316, used_mb: 316, used_percent: 100}}
+    end)
+
     assert capture_motd() =~ ~r/Memory usage : \e\[31m316 MB \(100%\).*\e\[0m/
   end
 

--- a/test/support/runtime.ex
+++ b/test/support/runtime.ex
@@ -28,7 +28,7 @@ defmodule NervesMOTD.Runtime.Host do
   def load_average(), do: ["0.35", "0.16", "0.11", "2/70", "1536"]
 
   @impl NervesMOTD.Runtime
-  def memory_usage(), do: [316_664, 78_408, 126_776, 12, 111_480, 238_564]
+  def memory_stats(), do: {:ok, %{size_mb: 316, used_mb: 78, used_percent: 25}}
 
   @impl NervesMOTD.Runtime
   def filesystem_stats(_filename), do: {:ok, %{size_mb: 14_619, used_mb: 37, used_percent: 0}}


### PR DESCRIPTION
Refactor memory stats related code using the same pattern as `filesystem_stats/1`.

### Notes

- Improve debug-ability by using intermediate variables instead of piping everything
- Do all the calculations within `NervesMOTD.Runtime` module
- Let  `memory_stats/0` return `{:ok, ...} | :error`
- `cmd "free -m"` did not return MB values so I manually calculated MB