### PR TITLE
Remove denominator from the applications section

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -124,14 +124,14 @@ defmodule NervesMOTD do
     loaded_count = length(apps[:loaded])
 
     if started_count == loaded_count do
-      {"Applications", :io_lib.format("~p / ~p", [started_count, loaded_count]), :green}
+      {"Applications", "#{started_count} started"}
     else
       not_started = Enum.join(apps[:loaded] -- apps[:started], ", ")
 
       {
         "Applications",
-        :io_lib.format("~p / ~p (~s not started)", [started_count, loaded_count, not_started]),
-        :red
+        :io_lib.format("~p started (~s not started)", [started_count, not_started]),
+        :yellow
       }
     end
   end

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -66,13 +66,13 @@ defmodule NervesMOTDTest do
   test "Applications when all apps started" do
     apps = %{started: [:a, :b, :c], loaded: [:a, :b, :c]}
     Mox.expect(NervesMOTD.MockRuntime, :applications, 1, fn -> apps end)
-    assert capture_motd() =~ ~r/Applications : \e\[32m\d* \/ \d*.*\e\[0m/
+    assert capture_motd() =~ ~r/Applications : \d* started/
   end
 
   test "Applications when not all apps started" do
     apps = %{started: [:b], loaded: [:a, :b, :c]}
     Mox.expect(NervesMOTD.MockRuntime, :applications, 1, fn -> apps end)
-    assert capture_motd() =~ ~r/Applications : \e\[31m\d* \/ \d* \(a, c not started\)\e\[0m/
+    assert capture_motd() =~ ~r/Applications : \e\[33m\d* started \(a, c not started\)\e\[0m/
   end
 
   test "Hostname" do


### PR DESCRIPTION
This is a quick fix for https://github.com/nerves-project/nerves_motd/issues/31 while we continue to look for an even better solution.

Currently denominator (loaded applications) is changeable at loading time, which can cause confusion because it looks like an error.

### Changes

- Remove denominator from the applications section
- Remove green color when all loaded apps are started
- Change red to yellow color when some loaded apps are not (yet) started

![nerves_motd--applications-aviod-confusion Screen Shot 2021-10-10 at 10 59 09 AM](https://user-images.githubusercontent.com/7563926/136701573-f6fc62b0-7062-467f-9154-469897aad79c.png)
