### PR TITLE
Drop support for Elixir 1.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,17 +66,6 @@ jobs:
       - run: mix deps.get
       - run: mix test
 
-  build_elixir_1_9_otp_22:
-    docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.18-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
 workflows:
   version: 2
   build_test:
@@ -84,4 +73,3 @@ workflows:
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_23
-      - build_elixir_1_9_otp_22

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NervesMOTD.MixProject do
     [
       app: :nerves_motd,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       docs: docs(),
       description: description(),


### PR DESCRIPTION
Elixir 1.9 is getting harder to support in other Nerves libraries. Given
that this project was created when Elixir 1.12 was available, it's
likely that no one is even using Elixir 1.9 anyway. Dropping it saves us
from having to maintain compatibility with it in an upcoming local time
PR.
