### PR TITLE
Rescue any print failure

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -49,6 +49,8 @@ defmodule NervesMOTD do
     ]
     |> IO.ANSI.format()
     |> IO.puts()
+  rescue
+    error -> IO.puts("Could not print MOTD: #{inspect(error)}")
   end
 
   @spec logo([option()]) :: iodata()

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -25,6 +25,10 @@ defmodule NervesMOTDTest do
     assert :ok = NervesMOTD.print()
   end
 
+  test "print failure" do
+    assert capture_motd("bad option") =~ ~r/Could not print MOTD: .*/
+  end
+
   @nerves_logo_regex ~r/N  E  R  V  E  S/
 
   test "Default logo" do


### PR DESCRIPTION
Currently when `NervesMOTD.print/1` causes an error for whatever reason, the subsequent content in `.iex.exs` won't get invoked. By rescuing any error within that function, we can avoid crashing `.iex.exs`.