### PR TITLE
Reset ANSI attributes after logo

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -50,6 +50,7 @@ defmodule NervesMOTD do
 
     [
       logo(opts),
+      IO.ANSI.reset(),
       uname(),
       "\n",
       Enum.map(rows(opts), &format_row/1),


### PR DESCRIPTION
This is a minor improvement. When a custom logo does not reset the ANSI attributes at the end, the first few lines get affected. I was able to recreate the issue:

![nerves-motd-logo-ansi-issue Screen Shot 2022-02-11 at 6 37 35 PM](https://user-images.githubusercontent.com/7563926/153686530-cf762683-96ac-486a-8249-a6098e5bea16.png)

**Solution**
- Call `IO.ANSI.reset/0` right after `logo/1`