### PR TITLE
Skip printing the MOTD if nerves_runtime unavailable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,8 @@ config :nerves_runtime, Nerves.Runtime.KV.Mock, %{
   "nerves_serial_number" => ""
 }
 
-config :nerves_motd, runtime_mod: NervesMOTD.MockRuntime
-
 config :nerves_time_zones, default_time_zone: "Asia/Tokyo"
+
+if Mix.env() == :test do
+  config :nerves_motd, runtime_mod: NervesMOTD.MockRuntime
+end

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -20,79 +20,123 @@ defmodule NervesMOTDTest do
     capture_io(fn -> NervesMOTD.print(opts) end)
   end
 
+  defp default_applications_code() do
+    fn -> %{started: [:nerves_runtime], loaded: []} end
+  end
+
   test "print" do
-    IO.puts("")
     assert :ok = NervesMOTD.print()
   end
 
   test "print failure" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd("bad option") =~ ~r/Could not print MOTD: .*/
   end
 
   @nerves_logo_regex ~r/N  E  R  V  E  S/
 
   test "Default logo" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ @nerves_logo_regex
   end
 
   test "Custom logo" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd(logo: "custom logo") =~ ~r/custom logo/
     refute capture_motd(logo: "custom logo") =~ @nerves_logo_regex
   end
 
   test "No logo" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     refute capture_motd(logo: "") =~ @nerves_logo_regex
   end
 
   test "Custom rows" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd(extra_rows: [[{"custom row", "hello"}]]) =~ ~r/hello/
   end
 
   test "Uname" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~
              ~r/nerves_livebook 0.2.17 \(0540f0cd-f95a-5596-d152-221a70c078a9\) arm rpi4/
   end
 
   test "Uptime" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ ~r/Uptime       : .*\d{0,2} seconds/
   end
 
   test "Clock" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ ~r/Clock        : \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \w{3}/
   end
 
   test "Firmware when valid" do
-    Mox.expect(NervesMOTD.MockRuntime, :firmware_valid?, 1, fn -> true end)
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+    |> Mox.expect(:firmware_valid?, 1, fn -> true end)
+
     assert capture_motd() =~ ~r/Firmware     : \e\[32mValid.*\e\[0m/
   end
 
   test "Firmware when invalid" do
-    Mox.expect(NervesMOTD.MockRuntime, :firmware_valid?, 1, fn -> false end)
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+    |> Mox.expect(:firmware_valid?, 1, fn -> false end)
+
     assert capture_motd() =~ ~r/Firmware     : \e\[31mNot validated.*\e\[0m/
   end
 
   test "Applications when all apps started" do
-    apps = %{started: [:a, :b, :c], loaded: [:a, :b, :c]}
+    apps = %{started: [:a, :b, :nerves_runtime], loaded: [:a, :b, :nerves_runtime]}
     Mox.expect(NervesMOTD.MockRuntime, :applications, 1, fn -> apps end)
     assert capture_motd() =~ ~r/Applications : \d* started/
   end
 
   test "Applications when not all apps started" do
-    apps = %{started: [:b], loaded: [:a, :b, :c]}
-    Mox.expect(NervesMOTD.MockRuntime, :applications, 1, fn -> apps end)
-    assert capture_motd() =~ ~r/Applications : \e\[33m\d* started \(a, c not started\)\e\[0m/
+    apps = %{started: [:nerves_runtime], loaded: [:a, :b, :nerves_runtime]}
+
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, fn -> apps end)
+
+    assert capture_motd() =~ ~r/Applications : \e\[33m\d* started \(a, b not started\)\e\[0m/
   end
 
   test "Hostname" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ ~r/Hostname     : [0-9a-zA-Z\-]*/
   end
 
   test "Memory usage when ok" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ ~r/Memory usage : 78 MB \(25%\)/
   end
 
   test "Memory usage when high" do
-    Mox.expect(NervesMOTD.MockRuntime, :memory_stats, 1, fn ->
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+    |> Mox.expect(:memory_stats, 1, fn ->
       {:ok, %{size_mb: 316, used_mb: 316, used_percent: 100}}
     end)
 
@@ -100,20 +144,31 @@ defmodule NervesMOTDTest do
   end
 
   test "Load average" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ ~r/Load average : 0.35 0.16 0.11/
   end
 
   test "Load average error" do
-    Mox.expect(NervesMOTD.MockRuntime, :load_average, 1, fn -> [] end)
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+    |> Mox.expect(:load_average, 1, fn -> [] end)
+
     assert capture_motd() =~ ~r/Load average : error/
   end
 
   test "Application partition usage" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ ~r/Part usage   : 37 MB \(0%\)/
   end
 
   test "Application partition usage high" do
-    Mox.expect(NervesMOTD.MockRuntime, :filesystem_stats, 1, fn _path ->
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+    |> Mox.expect(:filesystem_stats, 1, fn _path ->
       {:ok, %{size_mb: 14_300, used_mb: 12_900, used_percent: 90}}
     end)
 
@@ -121,7 +176,9 @@ defmodule NervesMOTDTest do
   end
 
   test "Application partition usage not available" do
-    Mox.expect(NervesMOTD.MockRuntime, :filesystem_stats, 1, fn _path ->
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+    |> Mox.expect(:filesystem_stats, 1, fn _path ->
       :error
     end)
 
@@ -129,6 +186,9 @@ defmodule NervesMOTDTest do
   end
 
   test "No application partition" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     old_devpath = Nerves.Runtime.KV.get_active("nerves_fw_application_part0_devpath")
     Nerves.Runtime.KV.put_active("nerves_fw_application_part0_devpath", nil)
     result = capture_motd()
@@ -137,6 +197,16 @@ defmodule NervesMOTDTest do
   end
 
   test "IP addresses" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
     assert capture_motd() =~ ~r/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,3}/
+  end
+
+  test "Doesn't print if nerves_runtime isn't started" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, fn -> %{started: [], loaded: []} end)
+
+    assert capture_motd() == ""
   end
 end


### PR DESCRIPTION
Originally `:nerves_runtime` was started if it wasn't running, but this
had a couple issues:

1. NervesMOTD is called very early in the boot process when IEx starts
   up. Loading `:nerves_runtime` here reorders the application load
   order from what's in the release script. It would be nice to not do
   that.
2. Applications are never fully loaded when this is called on boot. It's
   a little disconcerting to see a partially loaded system being
   reported on every boot. It's accurate, but not something many users
   expect and it looks like an error now since the application count
   is printed in red.
3. If somehow `:nerves_runtime` isn't started and you're still able to
   log into the system, it feels like forcing it to start is asking
   for trouble if you just want to grab debug info.

The new behavior is to just skip printing the MOTD if `:nerves_runtime`
isn't started.
