### PR TITLE
Update the Nerves CLI help URL

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -60,7 +60,7 @@ defmodule NervesMOTD do
         Enum.map(rows(apps, opts), &format_row/1),
         "\n",
         """
-        Nerves CLI help: https://hexdocs.pm/nerves/using-the-cli.html
+        Nerves CLI help: https://hexdocs.pm/nerves/iex-with-nerves.html
         """
       ]
       |> IO.ANSI.format()


### PR DESCRIPTION
### Description

Currently the Nerves CLI help URL is broken. The URL was changed in this commit https://github.com/nerves-project/nerves/commit/e7b32e97d7f3cb3169f0a534bd1987a8b4d38efd

![](https://user-images.githubusercontent.com/7563926/184501748-c8ac2419-93e6-494b-a849-173cc8b2fbc3.png)
![](https://user-images.githubusercontent.com/7563926/184501862-833c98bd-dbde-4698-b43c-8826e5404cbb.png)

### Changes

- Correct Nerves CLI help URL
  - from https://hexdocs.pm/nerves/using-the-cli.html (broken)
  - to https://hexdocs.pm/nerves/iex-with-nerves.html (good)

### Notes

- If we come up with better description than `"Nerves CLI help"`, we could change it as well.


 