### PR TITLE
Add logger message count to MOTD

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -61,6 +61,8 @@ defmodule NervesMOTD do
         "\n",
         """
         Nerves CLI help: https://hexdocs.pm/nerves/iex-with-nerves.html
+
+        #{logger_text()}
         """
       ]
       |> IO.ANSI.format()
@@ -77,6 +79,17 @@ defmodule NervesMOTD do
   @spec logo([option()]) :: IO.ANSI.ansidata()
   defp logo(opts) do
     Keyword.get(opts, :logo, @logo)
+  end
+
+  @spec logger_text() :: String.t()
+  defp logger_text() do
+    case runtime_mod().count_log_messages() do
+      {:ok, count} ->
+        "You have #{count} unread log messages"
+
+      _ ->
+        ""
+    end
   end
 
   @spec rows(map(), list()) :: [[cell()]]

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -59,6 +59,13 @@ defmodule NervesMOTDTest do
     refute capture_motd(logo: "") =~ @nerves_logo_regex
   end
 
+  test "Logger text" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
+    assert capture_motd() =~ ~r/You have 123 unread log messages/
+  end
+
   test "Custom rows" do
     NervesMOTD.MockRuntime
     |> Mox.expect(:applications, 1, default_applications_code())

--- a/test/support/runtime.ex
+++ b/test/support/runtime.ex
@@ -22,6 +22,9 @@ defmodule NervesMOTD.Runtime.Host do
   def applications(), do: %{loaded: @apps, started: @apps}
 
   @impl NervesMOTD.Runtime
+  def count_log_messages(), do: {:ok, 123}
+
+  @impl NervesMOTD.Runtime
   def cpu_temperature(), do: {:ok, 41.234}
 
   @impl NervesMOTD.Runtime


### PR DESCRIPTION
resolves https://github.com/nerves-project/nerves_motd/issues/80

![CleanShot 2022-10-30 at 20 12 40@2x](https://user-images.githubusercontent.com/7563926/198908901-675ba780-433f-4071-b3a2-9e1c2b811be2.png)

### Notes
- This should be on hold until https://github.com/nerves-project/nerves_motd/issues/96 is resolved since this adds more info to the MOTD
- Related PR: https://github.com/nerves-project/ring_logger/pull/99


### TODO

- [ ] update RingLogger to return statistics on types of messages
- [ ] adjust the count

