### PR TITLE
Add serial number

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -82,6 +82,7 @@ defmodule NervesMOTD do
   @spec rows(map(), list()) :: [[cell()]]
   defp rows(apps, opts) do
     [
+      [{"Serial", serial_number()}],
       [{"Uptime", uptime()}],
       [{"Clock", Utils.formatted_local_time()}],
       temperature_row(),
@@ -227,6 +228,11 @@ defmodule NervesMOTD do
       [a, b, c | _] -> [a, " ", b, " ", c]
       _ -> "error"
     end
+  end
+
+  @spec serial_number() :: String.t()
+  defp serial_number() do
+    Nerves.Runtime.serial_number()
   end
 
   @spec hostname() :: [byte()]

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -74,6 +74,15 @@ defmodule NervesMOTDTest do
              ~r/nerves_livebook 0.2.17 \(0540f0cd-f95a-5596-d152-221a70c078a9\) arm rpi4/
   end
 
+  test "Serial number" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 1, default_applications_code())
+
+    # Nerves.Runtime.serial_number() is expected to fail when running
+    # the regression tests since not using Nerves.
+    assert capture_motd() =~ ~r/Serial       : unconfigured/
+  end
+
   test "Uptime" do
     NervesMOTD.MockRuntime
     |> Mox.expect(:applications, 1, default_applications_code())


### PR DESCRIPTION
For the longest time, the serial number was super easy to grab from the
hostname. However, the hostname lowercases the serial number so it gets
annoying to manually recapitalize the serial when pasting in a text
sensitive field. This adds the serial number to the default output
unchanged to avoid any issues. Given how useful the serial number, it
seems like it should be listed early.
