### PR TITLE
Use application environment for default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ NervesMOTD.print(
 )
 ```
 
+For convenience, `NervesMOTD.print/1` options may be stored in the application environment in your `config.exs`:
+
+```elixir
+config :nerves_motd,
+  logo: """
+  Custom logo
+  """
+```
+
 ## Installation
 
 Install by adding `:nerves_motd` to your list of dependencies in `mix.exs`:

--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -49,15 +49,16 @@ defmodule NervesMOTD do
   """
   @spec print([option()]) :: :ok
   def print(opts \\ []) do
+    combined_opts = Application.get_all_env(:nerves_motd) |> Keyword.merge(opts)
     apps = runtime_mod().applications()
 
     if ready?(apps) do
       [
-        logo(opts),
+        logo(combined_opts),
         IO.ANSI.reset(),
         uname(),
         "\n",
-        Enum.map(rows(apps, opts), &format_row/1),
+        Enum.map(rows(apps, combined_opts), &format_row/1),
         "\n",
         """
         Nerves CLI help: https://hexdocs.pm/nerves/iex-with-nerves.html

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -29,9 +29,6 @@ defmodule NervesMOTDTest do
   end
 
   test "print failure" do
-    NervesMOTD.MockRuntime
-    |> Mox.expect(:applications, 1, default_applications_code())
-
     assert capture_motd("bad option") =~ ~r/Could not print MOTD: .*/
   end
 
@@ -54,6 +51,18 @@ defmodule NervesMOTDTest do
 
     assert capture_motd(logo: "custom logo") =~ ~r/custom logo/
     refute capture_motd(logo: "custom logo") =~ @nerves_logo_regex
+  end
+
+  test "Custom logo via Application environment" do
+    NervesMOTD.MockRuntime
+    |> Mox.expect(:applications, 2, default_applications_code())
+    |> Mox.expect(:active_partition, 2, fn -> "A" end)
+    |> Mox.expect(:firmware_validity, 2, fn -> :valid end)
+
+    Application.put_env(:nerves_motd, :logo, "app env logo")
+    assert capture_motd() =~ ~r/app env logo/
+    assert capture_motd(logo: "override logo") =~ ~r/override logo/
+    :application.unset_env(:nerves_motd, :logo)
   end
 
   test "No logo" do


### PR DESCRIPTION
This makes it possible to just run `NervesMOTD.print` to get the
complete customized version of the MOTD. This is nice when there's
something that NervesMOTD shows and you just want to see it again
without reconnecting.

Any option that can be given to `NervesMOTD.print` can be specified in
the Application environment for `:nerves_motd`. Options passed to
`print/1` take precendence like you'd expect.
