### PR TITLE
chore: credo fix

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -14,6 +14,7 @@ defmodule NervesMOTD do
   \e[38;5;24m███▌    \e[38;5;74m▀▀████\e[0m
   """
 
+  alias Nerves.Runtime.KV
   alias NervesMOTD.Utils
 
   @excluded_ifnames [~c"lo", ~c"lo0"]
@@ -208,7 +209,7 @@ defmodule NervesMOTD do
   @spec active_application_partition_cell() :: cell()
   defp active_application_partition_cell() do
     label = "Part usage"
-    app_partition_path = Nerves.Runtime.KV.get_active("nerves_fw_application_part0_devpath")
+    app_partition_path = KV.get_active("nerves_fw_application_part0_devpath")
 
     with true <- devpath_specified?(app_partition_path),
          {:ok, stats} <- runtime_mod().filesystem_stats(app_partition_path) do
@@ -231,11 +232,11 @@ defmodule NervesMOTD do
 
   @spec uname() :: IO.chardata()
   defp uname() do
-    fw_architecture = Nerves.Runtime.KV.get_active("nerves_fw_architecture")
-    fw_platform = Nerves.Runtime.KV.get_active("nerves_fw_platform")
-    fw_product = Nerves.Runtime.KV.get_active("nerves_fw_product")
-    fw_version = Nerves.Runtime.KV.get_active("nerves_fw_version")
-    fw_uuid = Nerves.Runtime.KV.get_active("nerves_fw_uuid")
+    fw_architecture = KV.get_active("nerves_fw_architecture")
+    fw_platform = KV.get_active("nerves_fw_platform")
+    fw_product = KV.get_active("nerves_fw_product")
+    fw_version = KV.get_active("nerves_fw_version")
+    fw_uuid = KV.get_active("nerves_fw_uuid")
     [fw_product, " ", fw_version, " (", fw_uuid, ") ", fw_architecture, " ", fw_platform]
   end
 

--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -28,6 +28,8 @@ defmodule NervesMOTD.Runtime.Target do
   @moduledoc false
   @behaviour NervesMOTD.Runtime
 
+  alias Nerves.Runtime.KV
+
   @impl NervesMOTD.Runtime
   def applications() do
     started = Enum.map(Application.started_applications(), &elem(&1, 0))
@@ -53,7 +55,7 @@ defmodule NervesMOTD.Runtime.Target do
 
   @impl NervesMOTD.Runtime
   def active_partition() do
-    case Nerves.Runtime.KV.get("nerves_fw_active") do
+    case KV.get("nerves_fw_active") do
       nil -> "unknown"
       partition -> String.upcase(partition)
     end

--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -116,11 +116,13 @@ defmodule NervesMOTD.Runtime.Target do
     _error -> :error
   end
 
-  if Code.ensure_loaded?(NervesTime) do
-    @impl NervesMOTD.Runtime
-    def time_synchronized?(), do: apply(NervesTime, :synchronized?, [])
-  else
-    @impl NervesMOTD.Runtime
-    def time_synchronized?(), do: true
+  case Code.ensure_compiled(NervesTime) do
+    {:module, _} ->
+      @impl NervesMOTD.Runtime
+      def time_synchronized?(), do: NervesTime.synchronized?()
+
+    _ ->
+      @impl NervesMOTD.Runtime
+      def time_synchronized?(), do: true
   end
 end

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -2,6 +2,7 @@ defmodule NervesMOTDTest do
   use ExUnit.Case
   doctest NervesMOTD
 
+  alias Nerves.Runtime.KV
   import ExUnit.CaptureIO
   import Mox
 
@@ -325,10 +326,10 @@ defmodule NervesMOTDTest do
     |> Mox.expect(:active_partition, 1, fn -> "A" end)
     |> Mox.expect(:firmware_validity, 1, fn -> :valid end)
 
-    old_devpath = Nerves.Runtime.KV.get_active("nerves_fw_application_part0_devpath")
-    Nerves.Runtime.KV.put_active("nerves_fw_application_part0_devpath", "")
+    old_devpath = KV.get_active("nerves_fw_application_part0_devpath")
+    KV.put_active("nerves_fw_application_part0_devpath", "")
     result = capture_motd()
-    Nerves.Runtime.KV.put_active("nerves_fw_application_part0_devpath", old_devpath)
+    KV.put_active("nerves_fw_application_part0_devpath", old_devpath)
     assert result =~ ~r/Part usage   : not available/
   end
 


### PR DESCRIPTION
Fix code per `mix credo --strict` generated recommendations.

- alias nested modules
- avoid using `apply/3` where possible