### PR TITLE
Fix target firmware validity check

### DIFF
--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -63,7 +63,7 @@ defmodule NervesMOTD.Runtime.Target do
 
   @impl NervesMOTD.Runtime
   def firmware_validity() do
-    :valid
+    if Nerves.Runtime.firmware_valid?(), do: :valid, else: :invalid
   end
 
   @impl NervesMOTD.Runtime


### PR DESCRIPTION
This reverts what has to have been an accidental change to fix an issue
when running on host.
