### PR TITLE
Match :inet.gethostname explicitly just in case

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -269,7 +269,8 @@ defmodule NervesMOTD do
 
   @spec hostname() :: [byte()]
   defp hostname() do
-    :inet.gethostname() |> elem(1)
+    {:ok, hostname} = :inet.gethostname()
+    hostname
   end
 
   @spec ip_address_rows() :: [[cell()]]


### PR DESCRIPTION
If this ever were to fail, the way it does is to give an invalid ANSI
escape sequence error due to the error reason not being a known atom.
This has never happened, but when reviewing the code for invalid ANSI
escape sequence errors, this was one place that was found.
