### PR TITLE
Ask df to use POSIX output format to not introduce /n characters in output

### DIFF
--- a/lib/nerves_motd/runtime.ex
+++ b/lib/nerves_motd/runtime.ex
@@ -103,7 +103,7 @@ defmodule NervesMOTD.Runtime.Target do
     #     Filesystem           1M-blocks      Used Available Use% Mounted on
     #     /dev/mmcblk0p4            1534       205      1329  13% /root
 
-    {df_results, 0} = System.cmd("df", ["-m", filename])
+    {df_results, 0} = System.cmd("df", ["-Pm", filename])
     [_title_row, results_row | _] = String.split(df_results, "\n")
     [_fs, size_mb_str, used_mb_str, _avail, used_percent_str | _] = String.split(results_row)
     {size_mb, ""} = Integer.parse(size_mb_str)


### PR DESCRIPTION
Hi there, in some specific cases, especially when you have "exotic" block device paths, the default output will introduce a \n character at the end of the filesystem path to keep the output aligned. This breaks the `filesystem_stats` function.

For instance:

```bash
Filesystem           1M-blocks      Used Available Use% Mounted on
dev                          1         0         1   0% /dev
run                         94         0        94   0% /run
/dev/mapper/mmcblk0p20p2
                            79        79         0 100% /
tmpfs                      188         0       188   0% /tmp
tmpfs                       94         0        94   0% /run
/dev/mapper/mmcblk0p20p1
                            50        16        31  35% /boot
/dev/mapper/mmcblk0p20p3
                           254        50       204  20% /root
tmpfs                        1         0         1   0% /sys/fs/cgroup
```

Fortunately, df has a way to force it to use standard POSIX output format and not introduce newline characters by passing the `-P` option. This should be a non breaking change that makes it safer for anyone tinkering with supporting nerves on weird devices...

The resulting output of `df -Pm` is:

```bash
Filesystem           1048576-blocks Used Available Capacity Mounted on
dev                          1         0         1   0% /dev
run                         94         0        94   0% /run
/dev/mapper/mmcblk0p20p2        79        79         0 100% /
tmpfs                      188         0       188   0% /tmp
tmpfs                       94         0        94   0% /run
/dev/mapper/mmcblk0p20p1        50        16        31  35% /boot
/dev/mapper/mmcblk0p20p3       254        50       204  20% /root
tmpfs                        1         0         1   0% /sys/fs/cgroup
```

Which is ugly but won't break `filesystem_stats`.