### PR TITLE
Add a newline after the `uname` output

### DIFF
--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -244,7 +244,7 @@ defmodule NervesMOTD do
     fw_product = KV.get_active("nerves_fw_product")
     fw_version = KV.get_active("nerves_fw_version")
     fw_uuid = KV.get_active("nerves_fw_uuid")
-    [fw_product, " ", fw_version, " (", fw_uuid, ") ", fw_architecture, " ", fw_platform]
+    [fw_product, " ", fw_version, " (", fw_uuid, ") ", fw_architecture, " ", fw_platform, "\n"]
   end
 
   # https://github.com/erlang/otp/blob/1c63b200a677ec7ac12202ddbcf7710884b16ff2/lib/stdlib/src/c.erl#L1118


### PR DESCRIPTION
A tiny PR which fixed a little (personal) visual annoyance.

From

```
Interactive Elixir (1.17.2) - press Ctrl+C to exit (type h() ENTER for help)
████▄▄    ▐███
█▌  ▀▀██▄▄  ▐█
█▌  ▄▄  ▀▀  ▐█   N  E  R  V  E  S
█▌  ▀▀██▄▄  ▐█
███▌    ▀▀████
the_cluster 0.1.7 (48b24420-c9c6-59a7-9d14-bf5be7a3c2f1) arm rpi4
  Serial       : 100000004b85eb20
  Uptime       : 3 days, 13 hours, 2 minutes and 36 seconds
  Clock        : 2025-08-17 23:19:16 UTC
  Temperature  : 55.0°C
```

To

```
Interactive Elixir (1.17.2) - press Ctrl+C to exit (type h() ENTER for help)
████▄▄    ▐███
█▌  ▀▀██▄▄  ▐█
█▌  ▄▄  ▀▀  ▐█   N  E  R  V  E  S
█▌  ▀▀██▄▄  ▐█
███▌    ▀▀████
the_cluster 0.1.7 (48b24420-c9c6-59a7-9d14-bf5be7a3c2f1) arm rpi4

  Serial       : 100000004b85eb20
  Uptime       : 3 days, 13 hours, 2 minutes and 36 seconds
  Clock        : 2025-08-17 23:19:16 UTC
  Temperature  : 55.0°C
```

I define a custom logo with the project I'm working on and add newlines above and below the logo for a little extra spacing. The only way I could add separation between the `uname` information and the rows section was with this PR. 