### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # nerves_motd
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_motd.svg "Hex version")](https://hex.pm/packages/nerves_motd)
-[![API docs](https://img.shields.io/hexpm/v/nerves_motd.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_motd/NervesMOTD.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_motd.svg?label=hexdocs "API docs")](https://nerves-motd.hexdocs.pm/NervesMOTD.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/nerves_motd/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/nerves_motd/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/nerves_motd)](https://api.reuse.software/info/github.com/nerves-project/nerves_motd)
 
@@ -75,9 +75,9 @@ def deps do
 end
 ```
 
-You can also install it using [Igniter](https://hexdocs.pm/igniter/) with `mix igniter.install nerves_motd`.
+You can also install it using [Igniter](https://igniter.hexdocs.pm/) with `mix igniter.install nerves_motd`.
 
-For details, see [API reference](https://hexdocs.pm/nerves_motd/api-reference.html).
+For details, see [API reference](https://nerves-motd.hexdocs.pm/api-reference.html).
 
 ## License
 

--- a/lib/mix/tasks/nerves_motd.install.ex
+++ b/lib/mix/tasks/nerves_motd.install.ex
@@ -106,7 +106,7 @@ else
       Mix.shell().error("""
       The task 'nerves_motd.install' requires igniter. Please install igniter and try again.
 
-      For more information, see: https://hexdocs.pm/igniter/readme.html#installation
+      For more information, see: https://igniter.hexdocs.pm/readme.html#installation
       """)
 
       exit({:shutdown, 1})

--- a/lib/nerves_motd.ex
+++ b/lib/nerves_motd.ex
@@ -70,7 +70,7 @@ defmodule NervesMOTD do
         Enum.map(rows(apps, combined_opts), &format_row/1),
         "\n",
         """
-        Nerves CLI help: https://hexdocs.pm/nerves/iex-with-nerves.html
+        Nerves CLI help: https://nerves.hexdocs.pm/iex-with-nerves.html
         """
       ]
       |> IO.ANSI.format()

--- a/test/nerves_motd_test.exs
+++ b/test/nerves_motd_test.exs
@@ -14,10 +14,10 @@ defmodule NervesMOTDTest do
 
   alias Nerves.Runtime.KV
 
-  # https://hexdocs.pm/mox/Mox.html#module-global-mode
+  # https://mox.hexdocs.pm/Mox.html#module-global-mode
   setup :set_mox_from_context
 
-  # https://hexdocs.pm/mox/Mox.html#verify_on_exit!/1
+  # https://mox.hexdocs.pm/Mox.html#verify_on_exit!/1
   setup :verify_on_exit!
 
   setup do


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-motd.hexdocs.pm/NervesMOTD.html): Status 404
❌ Verification failed for https://igniter.hexdocs.pm/): Status 301
❌ Verification failed for https://nerves-motd.hexdocs.pm/api-reference.html): Status 404
⚠️ Verification finished: 4 success, 3 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>